### PR TITLE
fix: ES6 dirname based on import

### DIFF
--- a/server/index.js
+++ b/server/index.js
@@ -1,8 +1,8 @@
 import express from 'express';
 import path from 'node:path';
+import { fileURLToPath } from 'node:url';
 
-// const __dirname = new URL('.', import.meta.url).pathname;
-const __dirname = path.parse(import.meta.url)['dir'].replace('file:///','');
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
 
 let app = express();
 app.use(express.urlencoded({ extended: true }));


### PR DESCRIPTION
The last `__dirname` declaration broke the use on Linux.

This implementation should usable on every system. Source: https://www.digitalocean.com/community/tutorials/nodejs-how-to-use__dirname

Need to be tesed on macOS and Windows